### PR TITLE
fix path to 'generated' directory

### DIFF
--- a/content/odd2odd.xql
+++ b/content/odd2odd.xql
@@ -33,7 +33,7 @@ declare function odd:compile($inputCol as xs:string, $odd as xs:string, $outputC
                 odd:get-compiled($inputCol, $name, $outputCol)[2],
             let $params :=
                 <parameters>
-                    <param name="currentDirectory" value="xmldb:exist://{$outputCol}"/>
+                    <param name="currentDirectory" value="xmldb:exist://{$outputCol}/"/>
                     <param name="lang" value="en"/>
                     <param name="exist:stop-on-warn" value="yes"/>
                     <param name="exist:stop-on-error" value="yes"/>


### PR DESCRIPTION
fixes this error when trying to compile odds (note missing '/' between 'compiled' and 'teisimple.odd'):

```
2015-06-13 23:14:05,683 [Thread-66] ERROR (EmbeddedDownload.java [stream]:143) - java.io.IOException: Resource /db/apps/tei-simple/odd/compiledteisimple.odd not found.
2015-06-13 23:14:05,683 [Thread-66] ERROR (EmbeddedDownloadThread.java [run]:100) - java.io.IOException: Resource /db/apps/tei-simple/odd/compiledteisimple.odd not found.
2015-06-13 23:14:05,694 [eXistThread-77] WARN  (Transform.java [fatalError]:817) - XSL transform reports fatal error: Processing terminated by xsl:message at line -1 in null
net.sf.saxon.expr.instruct.TerminationException: Processing terminated by xsl:message at line -1 in null
...
```
