### PR TITLE
Prepare 1.1.2 release

### DIFF
--- a/.existdb.json
+++ b/.existdb.json
@@ -1,0 +1,21 @@
+{
+    "servers": {
+        "localhost": {
+            "server": "http://localhost:8000/exist",
+            "user": "admin",
+            "password": ""
+        }
+    },
+    "sync": {
+        "server": "localhost",
+        "root": "/db/apps/tei-simple",
+        "active": true,
+        "ignore": [
+            ".existdb.json",
+            ".git/**",
+            "node_modules/**",
+            "bower_components/**",
+            "build/**"
+        ]
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 generated/
+expath-pkg.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TEI Processing Model Toolbox
 
+**Note:** The TEI Processing Model Toolbox has been superseded by TEI Publisher. See http://teipublisher.com for more information.
+
 The TEI Processing Model (PM) extends the TEI ODD specification format with a processing model for documents. That way intended processing for all elements can be expressed within the TEI vocubulary itself. It aims at the XML-savvy editor who is familiar with TEI but is not necessarily a developer.
 
 The TEI Processing Model Toolbox for eXist facilitates the integration of the TEI processing model into existing applications, supporting a range of different output media without requiring advanced coding skills. Customising the appearance of the text is all done in TEI by mapping each TEI element to a limited set of well-defined behaviour functions, e.g. “paragraph”, “heading”, “note”, “alternate”, etc. The TEI Processing Model includes a standard mapping, which can be extended by overwriting selected elements. Rendition styles are transparently translated into the different output media types like HTML, XSL-FO, LaTeX, or ePUB. Compared to traditional approaches with XSLT or XQuery, TEI Simple may thus easily save a few thousand lines of code for media specific stylesheets.

--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,7 @@
+#
+# Don't directly modify this file. Instead, copy it to local.build.properties and
+# edit that.
+#
+
+project.name=tei-pm
+project.version=1.1.2

--- a/build.xml
+++ b/build.xml
@@ -2,8 +2,6 @@
 <project default="all" name="TEI Processing Model Toolbox">
     <property file="local.build.properties"/>
     <property file="build.properties"/>
-    <property name="project.app" value="tei-pm"/>
-    <property name="project.version" value="1.1.0"/>
     <property name="server.url" value="http://demo.exist-db.org/exist/apps/public-repo/public/"/>
     <property name="build" value="build"/>
     <condition property="git.commit" value="${git.commit}" else="">
@@ -16,7 +14,13 @@
     </target>
     <target name="xar">
         <mkdir dir="${build}"/>
-        <zip basedir="." destfile="${build}/${project.app}-${project.version}${git.commit}.xar">
+        <copy file="expath-pkg.xml.tmpl" tofile="expath-pkg.xml" filtering="true" overwrite="true">
+            <filterset>
+                <filter token="project.name" value="${project.name}"/>
+                <filter token="project.version" value="${project.version}"/>
+            </filterset>
+        </copy>
+        <zip basedir="." destfile="${build}/${project.name}-${project.version}${git.commit}.xar">
             <exclude name="${build}/*"/>
             <exclude name=".git*"/>
             <exclude name="*.tmpl"/>
@@ -27,7 +31,7 @@
         <input message="Enter password:" addproperty="server.pass" defaultvalue="">
             <handler type="secure"/>
         </input>
-        <property name="xar" value="${project.app}-${project.version}${git.commit}.xar"/>
+        <property name="xar" value="${project.name}-${project.version}${git.commit}.xar"/>
         <exec executable="curl">
             <arg line="-T ${build}/${xar} -u admin:${server.pass} ${server.url}/${xar}"/>
         </exec>

--- a/expath-pkg.xml.tmpl
+++ b/expath-pkg.xml.tmpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package xmlns="http://expath.org/ns/pkg" name="http://www.tei-c.org/tei-simple" abbrev="tei-pm" version="1.1.0" spec="1.0">
+<package xmlns="http://expath.org/ns/pkg" name="http://www.tei-c.org/tei-simple" abbrev="@project.name@" version="@project.version@" spec="1.0">
     <title>TEI Processing Model Toolbox</title>
     <dependency processor="http://exist-db.org" semver-min="2.3.0"/>
     <dependency package="http://exist-db.org/apps/shared"/>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,9 @@
         </div>
         <div class="row">
             <div class="col-md-8 col-xs-12">
+                <p><span class="bold">NOTE:</span> The Instant Publishing Toolbox has been
+                    superseded by TEI Publisher. See <a href="http://teipublisher.com"
+                        >teipublisher.com</a> for more information.</p>
                 <p>
                     <span class="bold">Publish your data in various media formats without writing complex stylesheets</span>. Using the
                 <a href="http://htmlpreview.github.io/?https://github.com/TEIC/TEI-Simple/blob/master/tei-pm.html">TEI Processing Model</a>,

--- a/repo.xml
+++ b/repo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <meta xmlns="http://exist-db.org/xquery/repo">
-    <description>TEI Processing Model Toolbox</description>
+    <description>TEI Processing Model Toolbox (superseded by TEI Publisher)</description>
     <author>Wolfgang Meier</author>
     <website>http://showcases.exist-db.org/exist/apps/tei-pm</website>
     <status>stable</status>
@@ -11,4 +11,12 @@
     <prepare>pre-install.xql</prepare>
     <finish>post-install.xql</finish>
     <permissions xmlns:repo="http://exist-db.org/xquery/repo" password="simple" user="tei" group="tei" mode="rwxrwxr-x"/>
+    <changelog>
+        <change version="1.1.2">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>NOTE: TEI Processing Model Toolbox has been superseded by TEI Publisher</li>
+                <li>This is a minor maintenance release to allow applications to migrate to TEI Publisher</li>
+            </ul>
+        </change>
+    </changelog>
 </meta>


### PR DESCRIPTION
- bump to 1.1.2 (1.1.1 was on public-repo; repo was ahead)
- add note to README.md, index.html, and repo.xml release notes indicating that tei-simple-pm / tei-pm / TEI Processing Model Toolbox / Instant Publishing Toolbox is superseded by TEI Publisher, with links to teipublisher.com