### PR TITLE
Remove deprecated functions for eXist 5.x

### DIFF
--- a/content/css.xql
+++ b/content/css.xql
@@ -39,12 +39,12 @@ module namespace css="http://www.tei-c.org/tei-simple/xquery/css";
 declare namespace tei="http://www.tei-c.org/ns/1.0";
 
 declare function css:parse-css($css as xs:string) {
-    map:new(
+    map:merge(
         let $analyzed := analyze-string($css, "(.*?)\s*\{\s*([^\}]*?)\s*\}", "m")
         for $match in $analyzed/fn:match
         let $selectorString := $match/fn:group[@nr = "1"]/string()
         let $selectors := tokenize($selectorString, "\s*,\s*")
-        let $styles := map:new(
+        let $styles := map:merge(
             for $match in analyze-string($match/fn:group[@nr = "2"], "\s*(.*?)\s*\:\s*['&quot;]?(.*?)['&quot;]?(?:\;|$)")/fn:match
             return
                 map:entry($match/fn:group[1]/string(), $match/fn:group[2]/string())
@@ -102,7 +102,7 @@ declare function css:rendition-styles($config as map(*), $node as node()*) as ma
     let $renditions := $node//@rendition[starts-with(., "#")]
     return
         if ($renditions) then
-            map:new(
+            map:merge(
                 let $doc := ($config?parameters?root, root($node))[1]
                 for $renditionDef in $renditions
                 for $rendition in tokenize($renditionDef, "\s+")
@@ -119,7 +119,7 @@ declare function css:rendition-styles-html($config as map(*), $node as node()*) 
     let $styles := css:rendition-styles($config, $node)
     return
         if (exists($styles)) then
-            map:for-each-entry($styles, function($key, $value) {
+            map:for-each($styles, function($key, $value) {
                 "." || $key || " {&#10;" ||
                 "   " || $value || "&#10;" ||
                 "}&#10;&#10;"

--- a/content/fo-functions.xql
+++ b/content/fo-functions.xql
@@ -82,7 +82,7 @@ declare function pmf:init($config as map(*), $node as node()*) {
     let $renditionStyles := string-join(css:rendition-styles-html($config, $node))
     let $styles := if ($renditionStyles) then css:parse-css($renditionStyles) else map {}
     return
-        map:new(($config, map:entry("rendition-styles", $styles)))
+        map:merge(($config, map:entry("rendition-styles", $styles)))
 };
 
 declare function pmf:paragraph($config as map(*), $node as element(), $class as xs:string+, $content) {
@@ -467,11 +467,11 @@ declare function pmf:check-styles($config as map(*), $node as element()?, $class
         (),
     let $defaultStyles :=
         if (exists($default)) then
-            map:new(($default, $classes ! $config?default-styles(.)))
+            map:merge(($default, $classes ! $config?default-styles(.)))
         else
-            map:new($classes ! $config?default-styles(.))
+            map:merge($classes ! $config?default-styles(.))
     let $stylesForClass :=
-        map:new(
+        map:merge(
             for $class in $classes
             return (
                 pmf:filter-styles($config?styles?($class)),
@@ -506,7 +506,7 @@ declare %private function pmf:merge-maps($map as map(*), $defaults as map(*)?) {
     else if (empty($map)) then
         $defaults
     else
-        map:new(($defaults, $map))
+        map:merge(($defaults, $map))
 };
 
 declare %private function pmf:merge-styles($map as map(*)?, $defaults as map(*)?) {
@@ -515,11 +515,11 @@ declare %private function pmf:merge-styles($map as map(*)?, $defaults as map(*)?
     else if (empty($map)) then
         $defaults
     else
-        map:new((
-            map:for-each-entry($map, function($key, $value) {
-                map:entry($key, map:new(($map($key), $defaults($key))))
+        map:merge((
+            map:for-each($map, function($key, $value) {
+                map:entry($key, map:merge(($map($key), $defaults($key))))
             }),
-            map:for-each-entry($defaults, function($key, $value) {
+            map:for-each($defaults, function($key, $value) {
                 if (map:contains($map, $key)) then
                     ()
                 else
@@ -532,7 +532,7 @@ declare function pmf:load-styles($config as map(*), $root as document-node()) {
     let $css := css:generate-css($root)
     let $styles := css:parse-css($css)
     let $styles :=
-        map:new(($config, map:entry("styles", $styles)))
+        map:merge(($config, map:entry("styles", $styles)))
     return
         $styles
 };
@@ -543,7 +543,7 @@ declare function pmf:load-default-styles($config as map(*)) {
     let $userStyles := pmf:read-css($path)
     let $systemStyles := pmf:read-css(system:get-module-load-path() || "/styles.fo.css")
     return
-        map:new(($config, map:entry("default-styles", pmf:merge-styles($systemStyles, $userStyles))))
+        map:merge(($config, map:entry("default-styles", pmf:merge-styles($systemStyles, $userStyles))))
 };
 
 declare function pmf:read-css($path) {

--- a/content/latex-functions.xql
+++ b/content/latex-functions.xql
@@ -37,7 +37,7 @@ declare function pmf:init($config as map(*), $node as node()*) {
     let $renditionStyles := string-join(css:rendition-styles-html($config, $node))
     let $styles := if ($renditionStyles) then css:parse-css($renditionStyles) else map {}
     return
-        map:new(($config, map:entry("rendition-styles", $styles)))
+        map:merge(($config, map:entry("rendition-styles", $styles)))
 };
 
 declare function pmf:paragraph($config as map(*), $node as element(), $class as xs:string+, $content) {
@@ -61,7 +61,7 @@ declare function pmf:heading($config as map(*), $node as element(), $class as xs
         switch ($level)
             case 1 return
                 let $heading := normalize-space(pmf:get-content($config, $node, $class, $content))
-                let $configNoFn := map:new(($config, map { "skip-footnotes": true() }))
+                let $configNoFn := map:merge(($config, map { "skip-footnotes": true() }))
                 let $headingNoFn := pmf:get-content($configNoFn, $node, $class, $content)
                 return
                     "\" || $headType || "{" || $heading || "}\markboth{" || $headingNoFn || "}{" || $headingNoFn || "}&#10;&#10;"
@@ -368,11 +368,11 @@ declare %private function pmf:macros($config as map(*)) as map(*) {
             else
                 ()
     return
-        map:new(($config, map { "cssStyles": $config?styles, "styles": map:new($newStyles)}))
+        map:merge(($config, map { "cssStyles": $config?styles, "styles": map:merge($newStyles)}))
 };
 
 declare %private function pmf:define-styles($config as map(*), $classes as xs:string+, $content as item()*) {
-    let $styles := map:new(for $class in $classes return $config?styles($class))
+    let $styles := map:merge(for $class in $classes return $config?styles($class))
     let $text := string-join($content)
     return
         if (exists($styles)) then
@@ -517,15 +517,15 @@ declare %private function pmf:style($names as xs:string*, $styles as map(*), $te
 declare function pmf:load-styles($config as map(*), $root as document-node()) {
     let $css := css:generate-css($root)
     let $styles := css:parse-css($css)
-    let $styles := map:new(($config?rendition-styles, $styles))
-    let $config := pmf:macros(map:new(($config, map { "styles": $styles })))
+    let $styles := map:merge(($config?rendition-styles, $styles))
+    let $config := pmf:macros(map:merge(($config, map { "styles": $styles })))
     let $latexCode := (
         $pmf:MACROS,
         "% Styles&#10;",
-        map:for-each-entry($config?styles, function($class, $code) {
+        map:for-each($config?styles, function($class, $code) {
             $code
         })
     )
     return
-        map:new(($config, map {"latex-styles": $latexCode}))
+        map:merge(($config, map {"latex-styles": $latexCode}))
 };

--- a/content/model.xql
+++ b/content/model.xql
@@ -90,7 +90,7 @@ declare function pm:parse($odd as element(), $modules as array(*), $output as xs
                     <param>$input as node()*</param>
                     <body>
 let $config :=
-    map:new(($options,
+    map:merge(($options,
         map {{
             "output": [{ string-join(for $out in $output return '"' || $out || '"', ",")}],
             "odd": "{ document-uri(root($odd)) }",
@@ -208,7 +208,7 @@ $content ! (
 
 declare function pm:load-modules($modules as array(*)) as array(*) {
     array:for-each($modules, function($module) {
-        map:new(($module, map { "description": inspect:inspect-module(xs:anyURI($module?at)) }))
+        map:merge(($module, map { "description": inspect:inspect-module(xs:anyURI($module?at)) }))
     })
 };
 

--- a/content/util.xql
+++ b/content/util.xql
@@ -127,7 +127,7 @@ declare function pmu:process-odd($odd as document-node(), $output-root as xs:str
     let $ext-modules := pmu:parse-config($name, $mode, $config)
     let $module :=
         if (exists($ext-modules)) then
-            map:new(($modulesDefault, map:entry("modules", array { $modulesDefault?modules?*, $ext-modules })))
+            map:merge(($modulesDefault, map:entry("modules", array { $modulesDefault?modules?*, $ext-modules })))
         else
             $modulesDefault
     return
@@ -243,6 +243,6 @@ declare %private function pmu:fix-module-paths($modules as array(*)) {
             if (matches($module?at, "^(/|xmldb:).*")) then
                 $module
             else
-                map:new(($module, map:entry("at", system:get-module-load-path() || "/" || $module?at)))
+                map:merge(($module, map:entry("at", system:get-module-load-path() || "/" || $module?at)))
     }
 };

--- a/templates/basic/modules/app.xql
+++ b/templates/basic/modules/app.xql
@@ -83,7 +83,7 @@ function app:browse($node as node(), $model as map(*), $start as xs:int, $per-pa
         templates:process($node/*[@class="empty"], $model)
     else
         subsequence($model?all, $start, $per-page) !
-            templates:process($node/*[not(@class="empty")], map:new(($model, map { "work": . })))
+            templates:process($node/*[not(@class="empty")], map:merge(($model, map { "work": . })))
 };
 
 declare

--- a/transform/beamer-epub.xql
+++ b/transform/beamer-epub.xql
@@ -27,7 +27,7 @@ import module namespace epub="http://www.tei-c.org/tei-simple/xquery/functions/e
 declare function model:transform($options as map(*), $input as node()*) {
         
     let $config :=
-        map:new(($options,
+        map:merge(($options,
             map {
                 "output": ["epub","web"],
                 "odd": "/db/apps/tei-simple/odd/compiled/beamer.odd",

--- a/transform/beamer-latex.xql
+++ b/transform/beamer-latex.xql
@@ -29,7 +29,7 @@ import module namespace ext-latex="http://www.tei-c.org/tei-simple/xquery/ext-la
 declare function model:transform($options as map(*), $input as node()*) {
         
     let $config :=
-        map:new(($options,
+        map:merge(($options,
             map {
                 "output": ["latex","print"],
                 "odd": "/db/apps/tei-simple/odd/compiled/beamer.odd",

--- a/transform/beamer-print.xql
+++ b/transform/beamer-print.xql
@@ -27,7 +27,7 @@ import module namespace ext-fo="http://www.tei-c.org/tei-simple/xquery/ext-fo" a
 declare function model:transform($options as map(*), $input as node()*) {
         
     let $config :=
-        map:new(($options,
+        map:merge(($options,
             map {
                 "output": ["fo","print"],
                 "odd": "/db/apps/tei-simple/odd/compiled/beamer.odd",

--- a/transform/beamer-web.xql
+++ b/transform/beamer-web.xql
@@ -25,7 +25,7 @@ import module namespace html="http://www.tei-c.org/tei-simple/xquery/functions" 
 declare function model:transform($options as map(*), $input as node()*) {
         
     let $config :=
-        map:new(($options,
+        map:merge(($options,
             map {
                 "output": ["web"],
                 "odd": "/db/apps/tei-simple/odd/compiled/beamer.odd",

--- a/transform/documentation-epub.xql
+++ b/transform/documentation-epub.xql
@@ -29,7 +29,7 @@ import module namespace ext-html="http://www.tei-c.org/tei-simple/xquery/ext-htm
 declare function model:transform($options as map(*), $input as node()*) {
         
     let $config :=
-        map:new(($options,
+        map:merge(($options,
             map {
                 "output": ["epub","web"],
                 "odd": "/db/apps/tei-simple/odd/compiled/documentation.odd",

--- a/transform/documentation-latex.xql
+++ b/transform/documentation-latex.xql
@@ -27,7 +27,7 @@ import module namespace ext-latex="http://www.tei-c.org/tei-simple/xquery/ext-la
 declare function model:transform($options as map(*), $input as node()*) {
         
     let $config :=
-        map:new(($options,
+        map:merge(($options,
             map {
                 "output": ["latex","print"],
                 "odd": "/db/apps/tei-simple/odd/compiled/documentation.odd",

--- a/transform/documentation-print.xql
+++ b/transform/documentation-print.xql
@@ -27,7 +27,7 @@ import module namespace ext-fo="http://www.tei-c.org/tei-simple/xquery/ext-fo" a
 declare function model:transform($options as map(*), $input as node()*) {
         
     let $config :=
-        map:new(($options,
+        map:merge(($options,
             map {
                 "output": ["fo","print"],
                 "odd": "/db/apps/tei-simple/odd/compiled/documentation.odd",

--- a/transform/documentation-web.xql
+++ b/transform/documentation-web.xql
@@ -27,7 +27,7 @@ import module namespace ext-html="http://www.tei-c.org/tei-simple/xquery/ext-htm
 declare function model:transform($options as map(*), $input as node()*) {
         
     let $config :=
-        map:new(($options,
+        map:merge(($options,
             map {
                 "output": ["web"],
                 "odd": "/db/apps/tei-simple/odd/compiled/documentation.odd",

--- a/transform/myteisimple-epub.xql
+++ b/transform/myteisimple-epub.xql
@@ -27,7 +27,7 @@ import module namespace epub="http://www.tei-c.org/tei-simple/xquery/functions/e
 declare function model:transform($options as map(*), $input as node()*) {
         
     let $config :=
-        map:new(($options,
+        map:merge(($options,
             map {
                 "output": ["epub","web"],
                 "odd": "/db/apps/tei-simple/odd/compiled/myteisimple.odd",

--- a/transform/myteisimple-latex.xql
+++ b/transform/myteisimple-latex.xql
@@ -27,7 +27,7 @@ import module namespace ext-latex="http://www.tei-c.org/tei-simple/xquery/ext-la
 declare function model:transform($options as map(*), $input as node()*) {
         
     let $config :=
-        map:new(($options,
+        map:merge(($options,
             map {
                 "output": ["latex","print"],
                 "odd": "/db/apps/tei-simple/odd/compiled/myteisimple.odd",

--- a/transform/myteisimple-print.xql
+++ b/transform/myteisimple-print.xql
@@ -27,7 +27,7 @@ import module namespace ext-fo="http://www.tei-c.org/tei-simple/xquery/ext-fo" a
 declare function model:transform($options as map(*), $input as node()*) {
         
     let $config :=
-        map:new(($options,
+        map:merge(($options,
             map {
                 "output": ["fo","print"],
                 "odd": "/db/apps/tei-simple/odd/compiled/myteisimple.odd",

--- a/transform/myteisimple-web.xql
+++ b/transform/myteisimple-web.xql
@@ -25,7 +25,7 @@ import module namespace html="http://www.tei-c.org/tei-simple/xquery/functions" 
 declare function model:transform($options as map(*), $input as node()*) {
         
     let $config :=
-        map:new(($options,
+        map:merge(($options,
             map {
                 "output": ["web"],
                 "odd": "/db/apps/tei-simple/odd/compiled/myteisimple.odd",

--- a/transform/teisimple-epub.xql
+++ b/transform/teisimple-epub.xql
@@ -27,7 +27,7 @@ import module namespace epub="http://www.tei-c.org/tei-simple/xquery/functions/e
 declare function model:transform($options as map(*), $input as node()*) {
         
     let $config :=
-        map:new(($options,
+        map:merge(($options,
             map {
                 "output": ["epub","web"],
                 "odd": "/db/apps/tei-simple/odd/compiled/teisimple.odd",

--- a/transform/teisimple-latex.xql
+++ b/transform/teisimple-latex.xql
@@ -27,7 +27,7 @@ import module namespace ext-latex="http://www.tei-c.org/tei-simple/xquery/ext-la
 declare function model:transform($options as map(*), $input as node()*) {
         
     let $config :=
-        map:new(($options,
+        map:merge(($options,
             map {
                 "output": ["latex","print"],
                 "odd": "/db/apps/tei-simple/odd/compiled/teisimple.odd",

--- a/transform/teisimple-print.xql
+++ b/transform/teisimple-print.xql
@@ -27,7 +27,7 @@ import module namespace ext-fo="http://www.tei-c.org/tei-simple/xquery/ext-fo" a
 declare function model:transform($options as map(*), $input as node()*) {
         
     let $config :=
-        map:new(($options,
+        map:merge(($options,
             map {
                 "output": ["fo","print"],
                 "odd": "/db/apps/tei-simple/odd/compiled/teisimple.odd",

--- a/transform/teisimple-web.xql
+++ b/transform/teisimple-web.xql
@@ -25,7 +25,7 @@ import module namespace html="http://www.tei-c.org/tei-simple/xquery/functions" 
 declare function model:transform($options as map(*), $input as node()*) {
         
     let $config :=
-        map:new(($options,
+        map:merge(($options,
             map {
                 "output": ["web"],
                 "odd": "/db/apps/tei-simple/odd/compiled/teisimple.odd",


### PR DESCRIPTION
Problem: 
- tei-simple-pm wouldn't install on eXist 5.x

Solution:
- Ran @craigberry's audit script from https://github.com/craigberry/audit_exist_5x_removals
- Replaced/adapted the deprecated functions accordingly
- Used @wolfgangmm's approach for handling the difference between 4.x.x and 5.x.x versions of eXist concerning copying collections & resources (see https://github.com/eXist-db/eXide/pull/220)

Testing:
- Tested build, install, and first run on 4.7.0-SNAPSHOT and 5.0.0-SNAPSHOT (both develop and mavenized branch)
- The only hiccup was that *generating* an app yielded a “An error occurred while processing request to /exist/apps/tei-simple/modules/generator.xql: An error occurred: org.exist.storage.NodePath cannot be cast to org.exist.storage.NodePath2” error. This error went away when I applied https://github.com/eXist-db/exist/pull/2680. 

I'll be happy to publish a hotfix after this PR is merged. 